### PR TITLE
Upped jdk version to 1.7, fixed encoding.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,9 @@
 	<artifactId>consul-client</artifactId>
 	<version>0.7.1</version>
 	<inceptionYear>2008</inceptionYear>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
@@ -93,4 +96,17 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.0</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
Default jdk version was 1.5. Diamond inference was broken in build.